### PR TITLE
Improve debug logging and fix exit status

### DIFF
--- a/airship-cli/src/main/java/io/airlift/airship/cli/Airship.java
+++ b/airship-cli/src/main/java/io/airlift/airship/cli/Airship.java
@@ -79,6 +79,11 @@ import static org.iq80.cli.Cli.buildCli;
 
 public class Airship
 {
+    private static final int EXIT_SUCCESS = 0;
+    private static final int EXIT_FAILURE = 1;
+    private static final int EXIT_PERMANENT = 100;
+//    private static final int EXIT_TRANSIENT = 111;
+
     private static final File CONFIG_FILE = new File(System.getProperty("user.home", "."), ".airshipconfig");
 
     public static final Cli<AirshipCommand> AIRSHIP_PARSER;
@@ -139,15 +144,16 @@ public class Airship
             throws Exception
     {
         try {
-            AIRSHIP_PARSER.parse(args).call();
+            System.exit(AIRSHIP_PARSER.parse(args).call());
         }
         catch (ParseException e) {
             System.out.println(firstNonNull(e.getMessage(), "Unknown command line parser error"));
+            System.exit(EXIT_PERMANENT);
         }
     }
 
     public static abstract class AirshipCommand
-            implements Callable<Void>
+            implements Callable<Integer>
     {
         @Inject
         public GlobalOptions globalOptions = new GlobalOptions();
@@ -156,7 +162,7 @@ public class Airship
         public Config config;
 
         @Override
-        public final Void call()
+        public final Integer call()
                 throws Exception
         {
             initializeLogging(globalOptions.debug);
@@ -172,9 +178,10 @@ public class Airship
                 }
                 else {
                     System.out.println(firstNonNull(e.getMessage(), "Unknown error"));
+                    return EXIT_FAILURE;
                 }
             }
-            return null;
+            return EXIT_SUCCESS;
         }
 
         @VisibleForTesting

--- a/airship-cli/src/main/java/io/airlift/airship/cli/Airship.java
+++ b/airship-cli/src/main/java/io/airlift/airship/cli/Airship.java
@@ -42,6 +42,7 @@ import io.airlift.http.server.HttpServerInfo;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logging;
 import io.airlift.log.LoggingConfiguration;
+import io.airlift.log.LoggingMBean;
 import io.airlift.node.NodeInfo;
 import org.iq80.cli.Arguments;
 import org.iq80.cli.Cli;
@@ -1509,6 +1510,8 @@ public class Airship
             if (debug) {
                 Logging logging = new Logging();
                 logging.initialize(new LoggingConfiguration());
+                // TODO: add public level interface to logging framework
+                new LoggingMBean().setLevel("io.airlift.airship", "DEBUG");
             }
             else {
                 System.setOut(new PrintStream(new NullOutputStream()));


### PR DESCRIPTION
Previously, we always returned zero for an exit status, including for invalid commands and failures (unless `--debug` was set and an exception was thrown). This returns 1 for general failures and 100 for command parse errors.

It would be nice to return 111 for errors that are transient, but that's a lot more work.
