### PR TITLE
Hotfix for airlift builds

### DIFF
--- a/airship-agent/pom.xml
+++ b/airship-agent/pom.xml
@@ -147,4 +147,28 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <!-- This is a workaround for a bug in airbase 3, which is fixed in airbase 4. -->
+    <!-- Remove the maven-jar-plugin code (and the build section when switching to -->
+    <!-- released airbase 4 -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>${main-class}</mainClass>
+                            <addClasspath>true</addClasspath>
+                            <useUniqueVersions>false</useUniqueVersions>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <!-- This is a workaround for a bug in airbase 3, which is fixed in airbase 4. -->
+    <!-- Remove the maven-jar-plugin code (and the build section when switching to -->
+    <!-- released airbase 4 -->
 </project>

--- a/airship-coordinator/pom.xml
+++ b/airship-coordinator/pom.xml
@@ -171,6 +171,23 @@
                     <excludedGroups>aws</excludedGroups>
                 </configuration>
             </plugin>
+            <!-- This is a workaround for a bug in airbase 3, which is fixed in airbase 4. -->
+            <!-- Remove the maven-jar-plugin code when switching to released airbase 4.    -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>${main-class}</mainClass>
+                            <addClasspath>true</addClasspath>
+                            <useUniqueVersions>false</useUniqueVersions>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <!-- This is a workaround for a bug in airbase 3, which is fixed in airbase 4. -->
+            <!-- Remove the maven-jar-plugin code when switching to released airbase 4.    -->
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This adds main class and mainfest to the airship agent and coordinator
jars. It will happen automatically in airbase 4+.
