### PR TITLE
Allow for pushing configs through the coordinator to S3

### DIFF
--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/ConditionalModule.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/ConditionalModule.java
@@ -11,7 +11,7 @@ import static com.google.common.base.Preconditions.checkState;
 class ConditionalModule
         implements ConfigurationAwareModule
 {
-    public static ConfigurationAwareModule installIfPropertyEquals(Module module, String property, String expectedValue)
+    public static ConditionalModule installIfPropertyEquals(Module module, String property, String expectedValue)
     {
         return new ConditionalModule(module, property, expectedValue);
     }
@@ -20,12 +20,19 @@ class ConditionalModule
     private final String property;
     private final String expectedValue;
     private ConfigurationFactory configurationFactory;
+    private boolean allowUnset = false;
 
     private ConditionalModule(Module module, String property, String expectedValue)
     {
         this.module = checkNotNull(module, "module is null");
         this.property = checkNotNull(property, "property is null");
         this.expectedValue = checkNotNull(expectedValue, "expectedValue is null");
+    }
+
+    public ConditionalModule withAllowUnset(boolean allowUnset)
+    {
+      this.allowUnset = allowUnset;
+      return this;
     }
 
     @Override

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/ConditionalModule.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/ConditionalModule.java
@@ -31,8 +31,8 @@ class ConditionalModule
 
     public ConditionalModule withAllowUnset(boolean allowUnset)
     {
-      this.allowUnset = allowUnset;
-      return this;
+        this.allowUnset = allowUnset;
+        return this;
     }
 
     @Override

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorConfig.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorConfig.java
@@ -21,6 +21,7 @@ import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.Duration;
 
 import javax.validation.constraints.NotNull;
+
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -43,7 +44,7 @@ public class CoordinatorConfig
     private String s3RepoBucket;
     private String s3RepoKeyPrefix;
 
-  @NotNull
+    @NotNull
     public Duration getStatusExpiration()
     {
         return statusExpiration;

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorConfig.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorConfig.java
@@ -40,8 +40,10 @@ public class CoordinatorConfig
     private String httpShortNamePattern = DEFAULT_HTTP_SHORT_NAME_PATTERN;
     private String httpRepoBinaryVersionPattern;
     private String httpRepoConfigVersionPattern;
+    private String s3RepoBucket;
+    private String s3RepoKeyPrefix;
 
-    @NotNull
+  @NotNull
     public Duration getStatusExpiration()
     {
         return statusExpiration;
@@ -152,5 +154,29 @@ public class CoordinatorConfig
     {
         this.httpRepoConfigVersionPattern = httpRepoConfigVersionPattern;
         return this;
+    }
+
+    @Config("coordinator.s3-repo.bucket")
+    public CoordinatorConfig setS3RepoBucket(String s3RepoBucket)
+    {
+        this.s3RepoBucket = s3RepoBucket;
+        return this;
+    }
+
+    public String getS3RepoBucket()
+    {
+        return s3RepoBucket;
+    }
+
+    @Config("coordinator.s3-repo.keyPrefix")
+    public CoordinatorConfig setS3RepoKeyPrefix(String s3RepoKeyPrefix)
+    {
+        this.s3RepoKeyPrefix = s3RepoKeyPrefix;
+        return this;
+    }
+
+    public String getS3RepoKeyPrefix()
+    {
+        return s3RepoKeyPrefix;
     }
 }

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorConfigProxyResource.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorConfigProxyResource.java
@@ -1,0 +1,74 @@
+package io.airlift.airship.coordinator;
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.Resources;
+import io.airlift.airship.shared.Repository;
+import io.airlift.airship.shared.WritableRepository;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ */
+@Path("/v1/config")
+public class CoordinatorConfigProxyResource
+{
+  private final Repository repository;
+  private final WritableRepository writableRepository;
+
+  @Inject
+  public CoordinatorConfigProxyResource(
+      Repository repository
+  )
+  {
+    this.repository = Preconditions.checkNotNull(repository, "repository was null");
+    this.writableRepository = (WritableRepository) (repository instanceof WritableRepository ? repository : null);
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_OCTET_STREAM)
+  public Response getConfigs(
+      @QueryParam("identifier") String identifier
+  )
+  {
+    final URL url;
+    try {
+      url = repository.configToHttpUri(identifier).toURL();
+    }
+    catch (MalformedURLException e) {
+      return Response.status(Response.Status.NOT_FOUND).build();
+    }
+    return Response.ok(Resources.newInputStreamSupplier(url)).build();
+  }
+
+  @PUT
+  @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+  public Response createConfigs(
+      UriInfo info,
+      @QueryParam("identifier") String identifier,
+      InputStream configPayload
+  )
+  {
+    if (writableRepository == null) {
+      return Response.status(405).build();
+    }
+
+    if (writableRepository.configToHttpUri(identifier) != null) {
+      return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+
+    writableRepository.put(identifier, configPayload);
+    return Response.created(info.getRequestUri()).build();
+  }
+}

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorConfigProxyResource.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorConfigProxyResource.java
@@ -15,6 +15,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -24,51 +25,51 @@ import java.net.URL;
 @Path("/v1/config")
 public class CoordinatorConfigProxyResource
 {
-  private final Repository repository;
-  private final WritableRepository writableRepository;
+    private final Repository repository;
+    private final WritableRepository writableRepository;
 
-  @Inject
-  public CoordinatorConfigProxyResource(
-      Repository repository
-  )
-  {
-    this.repository = Preconditions.checkNotNull(repository, "repository was null");
-    this.writableRepository = (WritableRepository) (repository instanceof WritableRepository ? repository : null);
-  }
-
-  @GET
-  @Produces(MediaType.APPLICATION_OCTET_STREAM)
-  public Response getConfigs(
-      @QueryParam("identifier") String identifier
-  )
-  {
-    final URL url;
-    try {
-      url = repository.configToHttpUri(identifier).toURL();
-    }
-    catch (MalformedURLException e) {
-      return Response.status(Response.Status.NOT_FOUND).build();
-    }
-    return Response.ok(Resources.newInputStreamSupplier(url)).build();
-  }
-
-  @PUT
-  @Consumes(MediaType.APPLICATION_OCTET_STREAM)
-  public Response createConfigs(
-      UriInfo info,
-      @QueryParam("identifier") String identifier,
-      InputStream configPayload
-  )
-  {
-    if (writableRepository == null) {
-      return Response.status(405).build();
+    @Inject
+    public CoordinatorConfigProxyResource(
+            Repository repository
+    )
+    {
+        this.repository = Preconditions.checkNotNull(repository, "repository was null");
+        this.writableRepository = (WritableRepository) (repository instanceof WritableRepository ? repository : null);
     }
 
-    if (writableRepository.configToHttpUri(identifier) != null) {
-      return Response.status(Response.Status.BAD_REQUEST).build();
+    @GET
+    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    public Response getConfigs(
+            @QueryParam("identifier") String identifier
+    )
+    {
+        final URL url;
+        try {
+            url = repository.configToHttpUri(identifier).toURL();
+        }
+        catch (MalformedURLException e) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.ok(Resources.newInputStreamSupplier(url)).build();
     }
 
-    writableRepository.put(identifier, configPayload);
-    return Response.created(info.getRequestUri()).build();
-  }
+    @PUT
+    @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+    public Response createConfigs(
+            UriInfo info,
+            @QueryParam("identifier") String identifier,
+            InputStream configPayload
+    )
+    {
+        if (writableRepository == null) {
+            return Response.status(405).build();
+        }
+
+        if (writableRepository.configToHttpUri(identifier) != null) {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+
+        writableRepository.put(identifier, configPayload);
+        return Response.created(info.getRequestUri()).build();
+    }
 }

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/S3Repository.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/S3Repository.java
@@ -13,6 +13,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import io.airlift.airship.shared.WritableRepository;
+import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
 
 import java.io.InputStream;
@@ -27,226 +28,226 @@ import static io.airlift.airship.shared.MavenCoordinates.DEFAULT_CONFIG_PACKAGIN
  * A WritableRepository implemented on top of S3.  This repository does not support updating by just a version,
  * it requires the full artifact identifier to be specified.
  */
-public class S3Repository implements WritableRepository
+public class S3Repository
+        implements WritableRepository
 {
-  private final AmazonS3 s3Client;
-  private final String bucket;
-  private final String keyPrefix;
+    private final AmazonS3 s3Client;
+    private final String bucket;
+    private final String keyPrefix;
 
-  @Inject
-  public S3Repository(
-      AmazonS3 s3Client,
-      CoordinatorConfig config
-  )
-  {
-    this(s3Client, config.getS3RepoBucket(), config.getS3RepoKeyPrefix());
-  }
-
-  public S3Repository(
-      AmazonS3 s3Client,
-      String bucket,
-      String keyPrefix
-  )
-  {
-    this.s3Client = Preconditions.checkNotNull(s3Client, "s3Client was null");
-    this.bucket = Preconditions.checkNotNull(bucket, "bucket was null");
-    this.keyPrefix = keyPrefix == null
-                     ? "/"
-                     : (keyPrefix.endsWith("/") ? keyPrefix : keyPrefix + "/"); // Always end the prefix with a slash
-  }
-
-  @Override
-  public String configShortName(String config)
-  {
-    if (!config.startsWith("@")) {
-      return null;
-    }
-    config = config.substring(1);
-
-    return config;
-  }
-
-  @Override
-  public String configRelativize(String config)
-  {
-    if (!config.startsWith("@")) {
-      return null;
-    }
-    return null;
-  }
-
-  @Override
-  public String configResolve(String config)
-  {
-    if (!config.startsWith("@")) {
-      return null;
-    }
-    config = config.substring(1);
-
-    URI uri = toHttpUri(config, DEFAULT_CONFIG_PACKAGING);
-    if (uri != null) {
-      return "@" + config;
-    }
-    return null;
-  }
-
-  @Override
-  public String configUpgrade(String config, String version)
-  {
-    if (!config.startsWith("@") || !version.startsWith("@")) {
-      return null;
-    }
-    version = version.substring(1);
-    String upgrade = upgrade(version, DEFAULT_CONFIG_PACKAGING);
-    if (upgrade != null) {
-      return "@" + upgrade;
-    }
-    return null;
-  }
-
-  @Override
-  public boolean configEqualsIgnoreVersion(String config1, String config2)
-  {
-    return config1.startsWith("@") &&
-           config2.startsWith("@") &&
-           config1.equals(config2);
-  }
-
-  @Override
-  public URI configToHttpUri(String config)
-  {
-    if (!config.startsWith("@")) {
-      return null;
-    }
-    config = config.substring(1);
-    return toHttpUri(config, DEFAULT_CONFIG_PACKAGING);
-  }
-
-  @Override
-  public String binaryRelativize(String binary)
-  {
-    return null;
-  }
-
-  @Override
-  public String binaryResolve(String binary)
-  {
-    URI uri = toHttpUri(binary, DEFAULT_BINARY_PACKAGING);
-    if (uri != null) {
-      return binary;
-    }
-    return null;
-  }
-
-  @Override
-  public String binaryUpgrade(String binary, String version)
-  {
-    return upgrade(version, DEFAULT_BINARY_PACKAGING);
-  }
-
-  @Override
-  public boolean binaryEqualsIgnoreVersion(String binary1, String binary2)
-  {
-    return binary1.equals(binary2);
-  }
-
-  @Override
-  public URI binaryToHttpUri(String binary)
-  {
-    return toHttpUri(binary, DEFAULT_BINARY_PACKAGING);
-  }
-
-  private String upgrade(String version, String defaultPackaging)
-  {
-    // version pattern did not match, so check if new version is an absolute uri
-    URI uri = toHttpUri(version, defaultPackaging);
-    if (uri != null) {
-      return version;
-    }
-    return null;
-  }
-
-  private URI toHttpUri(String path, String defaultExtension)
-  {
-    String key = makeKey(path);
-    if (exists(key)) {
-      return makeUri(key);
+    @Inject
+    public S3Repository(
+            AmazonS3 s3Client,
+            CoordinatorConfig config
+    )
+    {
+        this(s3Client, config.getS3RepoBucket(), config.getS3RepoKeyPrefix());
     }
 
-    key = key + "." + defaultExtension;
-    if (exists(key)) {
-      return makeUri(key);
+    public S3Repository(
+            AmazonS3 s3Client,
+            String bucket,
+            String keyPrefix
+    )
+    {
+        this.s3Client = Preconditions.checkNotNull(s3Client, "s3Client was null");
+        this.bucket = Preconditions.checkNotNull(bucket, "bucket was null");
+        this.keyPrefix = keyPrefix == null
+                ? ""
+                : (keyPrefix.endsWith("/") ? keyPrefix : StringUtils.stripEnd(keyPrefix, "/")); // no slashes at end of prefix
     }
 
-    return null;
-  }
+    @Override
+    public String configShortName(String config)
+    {
+        if (!config.startsWith("@")) {
+            return null;
+        }
+        config = config.substring(1);
 
-  private String makeKey(String path)
-  {
-    if (path.startsWith("/")) {
-      return keyPrefix + path;
+        return config;
     }
-    return keyPrefix + "/" + path;
-  }
 
-  private boolean exists(final String key)
-  {
-    try {
-      s3Client.getObjectMetadata(bucket, key);
-      return true;
+    @Override
+    public String configRelativize(String config)
+    {
+        if (!config.startsWith("@")) {
+            return null;
+        }
+        return null;
     }
-    catch (AmazonServiceException e) {
-      return false;
+
+    @Override
+    public String configResolve(String config)
+    {
+        if (!config.startsWith("@")) {
+            return null;
+        }
+        config = config.substring(1);
+
+        URI uri = toHttpUri(config, DEFAULT_CONFIG_PACKAGING);
+        if (uri != null) {
+            return "@" + config;
+        }
+        return null;
     }
-  }
 
-  private URI makeUri(String key)
-  {
-    try {
-      return s3Client.generatePresignedUrl(bucket, key, new DateTime().plusMinutes(15).toDate(), HttpMethod.GET)
-                     .toURI();
+    @Override
+    public String configUpgrade(String config, String version)
+    {
+        if (!config.startsWith("@") || !version.startsWith("@")) {
+            return null;
+        }
+        version = version.substring(1);
+        String upgrade = upgrade(version, DEFAULT_CONFIG_PACKAGING);
+        if (upgrade != null) {
+            return "@" + upgrade;
+        }
+        return null;
     }
-    catch (URISyntaxException e) {
-      throw Throwables.propagate(e);
+
+    @Override
+    public boolean configEqualsIgnoreVersion(String config1, String config2)
+    {
+        return config1.startsWith("@") &&
+                config2.startsWith("@") &&
+                config1.equals(config2);
     }
-  }
 
-
-  @Override
-  public String toString()
-  {
-    final StringBuilder sb = new StringBuilder();
-    sb.append("S3Repository");
-    sb.append("{bucket=").append(bucket);
-    sb.append(", keyPrefix=").append(keyPrefix);
-    sb.append('}');
-    return sb.toString();
-  }
-
-  @Override
-  public void put(String key, InputStream inputStream)
-  {
-    key = makeKey(key);
-
-    final InitiateMultipartUploadResult multipart = s3Client.initiateMultipartUpload(
-        new InitiateMultipartUploadRequest(bucket, key)
-    );
-
-    try {
-      final UploadPartResult partResult = s3Client.uploadPart(
-          new UploadPartRequest().withBucketName(bucket)
-                                 .withKey(key)
-                                 .withLastPart(true)
-                                 .withInputStream(inputStream)
-                                 .withUploadId(multipart.getUploadId())
-      );
-
-      s3Client.completeMultipartUpload(
-          new CompleteMultipartUploadRequest(bucket, key, multipart.getUploadId(), Arrays.asList(partResult.getPartETag()))
-      );
+    @Override
+    public URI configToHttpUri(String config)
+    {
+        if (!config.startsWith("@")) {
+            return null;
+        }
+        config = config.substring(1);
+        return toHttpUri(config, DEFAULT_CONFIG_PACKAGING);
     }
-    catch (RuntimeException e) {
-      s3Client.abortMultipartUpload(new AbortMultipartUploadRequest(bucket, key, multipart.getUploadId()));
+
+    @Override
+    public String binaryRelativize(String binary)
+    {
+        return null;
     }
-  }
+
+    @Override
+    public String binaryResolve(String binary)
+    {
+        URI uri = toHttpUri(binary, DEFAULT_BINARY_PACKAGING);
+        if (uri != null) {
+            return binary;
+        }
+        return null;
+    }
+
+    @Override
+    public String binaryUpgrade(String binary, String version)
+    {
+        return upgrade(version, DEFAULT_BINARY_PACKAGING);
+    }
+
+    @Override
+    public boolean binaryEqualsIgnoreVersion(String binary1, String binary2)
+    {
+        return binary1.equals(binary2);
+    }
+
+    @Override
+    public URI binaryToHttpUri(String binary)
+    {
+        return toHttpUri(binary, DEFAULT_BINARY_PACKAGING);
+    }
+
+    private String upgrade(String version, String defaultPackaging)
+    {
+        // version pattern did not match, so check if new version is an absolute uri
+        URI uri = toHttpUri(version, defaultPackaging);
+        if (uri != null) {
+            return version;
+        }
+        return null;
+    }
+
+    private URI toHttpUri(String path, String defaultExtension)
+    {
+        String key = makeKey(path);
+        if (exists(key)) {
+            return makeUri(key);
+        }
+
+        key = key + "." + defaultExtension;
+        if (exists(key)) {
+            return makeUri(key);
+        }
+
+        return null;
+    }
+
+    private String makeKey(String path)
+    {
+        if (path.startsWith("/")) {
+            return keyPrefix + path;
+        }
+        return keyPrefix + "/" + path;
+    }
+
+    private boolean exists(final String key)
+    {
+        try {
+            s3Client.getObjectMetadata(bucket, key);
+            return true;
+        }
+        catch (AmazonServiceException e) {
+            return false;
+        }
+    }
+
+    private URI makeUri(String key)
+    {
+        try {
+            return s3Client.generatePresignedUrl(bucket, key, new DateTime().plusMinutes(15).toDate(), HttpMethod.GET)
+                    .toURI();
+        }
+        catch (URISyntaxException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("S3Repository");
+        sb.append("{bucket=").append(bucket);
+        sb.append(", keyPrefix=").append(keyPrefix);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public void put(String key, InputStream inputStream)
+    {
+        key = makeKey(key);
+
+        final InitiateMultipartUploadResult multipart = s3Client.initiateMultipartUpload(
+                new InitiateMultipartUploadRequest(bucket, key)
+        );
+
+        try {
+            final UploadPartResult partResult = s3Client.uploadPart(
+                    new UploadPartRequest().withBucketName(bucket)
+                            .withKey(key)
+                            .withLastPart(true)
+                            .withInputStream(inputStream)
+                            .withUploadId(multipart.getUploadId())
+            );
+
+            s3Client.completeMultipartUpload(
+                    new CompleteMultipartUploadRequest(bucket, key, multipart.getUploadId(), Arrays.asList(partResult.getPartETag()))
+            );
+        }
+        catch (RuntimeException e) {
+            s3Client.abortMultipartUpload(new AbortMultipartUploadRequest(bucket, key, multipart.getUploadId()));
+        }
+    }
 }

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/S3Repository.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/S3Repository.java
@@ -1,0 +1,252 @@
+package io.airlift.airship.coordinator;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import io.airlift.airship.shared.WritableRepository;
+import org.joda.time.DateTime;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+
+import static io.airlift.airship.shared.MavenCoordinates.DEFAULT_BINARY_PACKAGING;
+import static io.airlift.airship.shared.MavenCoordinates.DEFAULT_CONFIG_PACKAGING;
+
+/**
+ * A WritableRepository implemented on top of S3.  This repository does not support updating by just a version,
+ * it requires the full artifact identifier to be specified.
+ */
+public class S3Repository implements WritableRepository
+{
+  private final AmazonS3 s3Client;
+  private final String bucket;
+  private final String keyPrefix;
+
+  @Inject
+  public S3Repository(
+      AmazonS3 s3Client,
+      CoordinatorConfig config
+  )
+  {
+    this(s3Client, config.getS3RepoBucket(), config.getS3RepoKeyPrefix());
+  }
+
+  public S3Repository(
+      AmazonS3 s3Client,
+      String bucket,
+      String keyPrefix
+  )
+  {
+    this.s3Client = Preconditions.checkNotNull(s3Client, "s3Client was null");
+    this.bucket = Preconditions.checkNotNull(bucket, "bucket was null");
+    this.keyPrefix = keyPrefix == null
+                     ? "/"
+                     : (keyPrefix.endsWith("/") ? keyPrefix : keyPrefix + "/"); // Always end the prefix with a slash
+  }
+
+  @Override
+  public String configShortName(String config)
+  {
+    if (!config.startsWith("@")) {
+      return null;
+    }
+    config = config.substring(1);
+
+    return config;
+  }
+
+  @Override
+  public String configRelativize(String config)
+  {
+    if (!config.startsWith("@")) {
+      return null;
+    }
+    return null;
+  }
+
+  @Override
+  public String configResolve(String config)
+  {
+    if (!config.startsWith("@")) {
+      return null;
+    }
+    config = config.substring(1);
+
+    URI uri = toHttpUri(config, DEFAULT_CONFIG_PACKAGING);
+    if (uri != null) {
+      return "@" + config;
+    }
+    return null;
+  }
+
+  @Override
+  public String configUpgrade(String config, String version)
+  {
+    if (!config.startsWith("@") || !version.startsWith("@")) {
+      return null;
+    }
+    version = version.substring(1);
+    String upgrade = upgrade(version, DEFAULT_CONFIG_PACKAGING);
+    if (upgrade != null) {
+      return "@" + upgrade;
+    }
+    return null;
+  }
+
+  @Override
+  public boolean configEqualsIgnoreVersion(String config1, String config2)
+  {
+    return config1.startsWith("@") &&
+           config2.startsWith("@") &&
+           config1.equals(config2);
+  }
+
+  @Override
+  public URI configToHttpUri(String config)
+  {
+    if (!config.startsWith("@")) {
+      return null;
+    }
+    config = config.substring(1);
+    return toHttpUri(config, DEFAULT_CONFIG_PACKAGING);
+  }
+
+  @Override
+  public String binaryRelativize(String binary)
+  {
+    return null;
+  }
+
+  @Override
+  public String binaryResolve(String binary)
+  {
+    URI uri = toHttpUri(binary, DEFAULT_BINARY_PACKAGING);
+    if (uri != null) {
+      return binary;
+    }
+    return null;
+  }
+
+  @Override
+  public String binaryUpgrade(String binary, String version)
+  {
+    return upgrade(version, DEFAULT_BINARY_PACKAGING);
+  }
+
+  @Override
+  public boolean binaryEqualsIgnoreVersion(String binary1, String binary2)
+  {
+    return binary1.equals(binary2);
+  }
+
+  @Override
+  public URI binaryToHttpUri(String binary)
+  {
+    return toHttpUri(binary, DEFAULT_BINARY_PACKAGING);
+  }
+
+  private String upgrade(String version, String defaultPackaging)
+  {
+    // version pattern did not match, so check if new version is an absolute uri
+    URI uri = toHttpUri(version, defaultPackaging);
+    if (uri != null) {
+      return version;
+    }
+    return null;
+  }
+
+  private URI toHttpUri(String path, String defaultExtension)
+  {
+    String key = makeKey(path);
+    if (exists(key)) {
+      return makeUri(key);
+    }
+
+    key = key + "." + defaultExtension;
+    if (exists(key)) {
+      return makeUri(key);
+    }
+
+    return null;
+  }
+
+  private String makeKey(String path)
+  {
+    if (path.startsWith("/")) {
+      return keyPrefix + path;
+    }
+    return keyPrefix + "/" + path;
+  }
+
+  private boolean exists(final String key)
+  {
+    try {
+      s3Client.getObjectMetadata(bucket, key);
+      return true;
+    }
+    catch (AmazonServiceException e) {
+      return false;
+    }
+  }
+
+  private URI makeUri(String key)
+  {
+    try {
+      return s3Client.generatePresignedUrl(bucket, key, new DateTime().plusMinutes(15).toDate(), HttpMethod.GET)
+                     .toURI();
+    }
+    catch (URISyntaxException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+
+  @Override
+  public String toString()
+  {
+    final StringBuilder sb = new StringBuilder();
+    sb.append("S3Repository");
+    sb.append("{bucket=").append(bucket);
+    sb.append(", keyPrefix=").append(keyPrefix);
+    sb.append('}');
+    return sb.toString();
+  }
+
+  @Override
+  public void put(String key, InputStream inputStream)
+  {
+    key = makeKey(key);
+
+    final InitiateMultipartUploadResult multipart = s3Client.initiateMultipartUpload(
+        new InitiateMultipartUploadRequest(bucket, key)
+    );
+
+    try {
+      final UploadPartResult partResult = s3Client.uploadPart(
+          new UploadPartRequest().withBucketName(bucket)
+                                 .withKey(key)
+                                 .withLastPart(true)
+                                 .withInputStream(inputStream)
+                                 .withUploadId(multipart.getUploadId())
+      );
+
+      s3Client.completeMultipartUpload(
+          new CompleteMultipartUploadRequest(bucket, key, multipart.getUploadId(), Arrays.asList(partResult.getPartETag()))
+      );
+    }
+    catch (RuntimeException e) {
+      s3Client.abortMultipartUpload(new AbortMultipartUploadRequest(bucket, key, multipart.getUploadId()));
+    }
+  }
+}

--- a/airship-shared/src/main/java/io/airlift/airship/shared/WritableRepository.java
+++ b/airship-shared/src/main/java/io/airlift/airship/shared/WritableRepository.java
@@ -1,0 +1,10 @@
+package io.airlift.airship.shared;
+
+import java.io.InputStream;
+
+/**
+ */
+public interface WritableRepository extends Repository
+{
+  public void put(String key, InputStream inputStream);
+}

--- a/airship-shared/src/main/java/io/airlift/airship/shared/WritableRepository.java
+++ b/airship-shared/src/main/java/io/airlift/airship/shared/WritableRepository.java
@@ -4,7 +4,8 @@ import java.io.InputStream;
 
 /**
  */
-public interface WritableRepository extends Repository
+public interface WritableRepository
+        extends Repository
 {
-  public void put(String key, InputStream inputStream);
+    public void put(String key, InputStream inputStream);
 }


### PR DESCRIPTION
This is a pull request more as a question of if this is a completely horrible direction and you are morally opposed to it, or if something along these lines is actually acceptable.  I believe that setting up a maven repository on the side for the storage of config bundles is too much friction to actually get started, so I'm trying to come up with another option that could be done with much less friction.  

The idea was that if I can push configs to the coordinator then the world would be a bit nicer.  The big issue is that Repositories are read-only and generate URIs for the actual reading, so it is a little awkward to add "put" methods on the Repository interface (things like HttpRepository cannot really implement it meaningfully).  Anyway, these are my changes, let me know if this is a direction I should continue pursuing.

1) Introduce WritableRepository interface as a method of allowing for a repository to define how to push items instead of just being able to pull them.
2) Create S3Repository that implements WritableRepository and works off stuff existing in an s3 bucket somewhere
3) Introduce CoordinatorConfigProxyResource which is a simple resource that allows for the getting of configs.  It will also allow for the setting if the Repository instance implements WritableRepository
4) Some stuff to make it Guice inject, I think...
