### PR TITLE
Removed region specific IAM user creation

### DIFF
--- a/airship-cli/src/main/java/io/airlift/airship/cli/Airship.java
+++ b/airship-cli/src/main/java/io/airlift/airship/cli/Airship.java
@@ -1137,9 +1137,6 @@ public class Airship
 
             // generate new keys for the cluster
             AmazonIdentityManagementClient iamClient = new AmazonIdentityManagementClient(new BasicAWSCredentials(accessKey, secretKey));
-            if (awsEndpoint != null) {
-                iamClient.setEndpoint(awsEndpoint);
-            }
             String username = createIamUserForEnvironment(iamClient, environment);
 
             // save the environment since we just created a permanent resource


### PR DESCRIPTION
It should always go directly through the default EC2 endpoint and in fact fails otherwise.
