### PR TITLE
Changed the location of aws-credentials.properties

### DIFF
--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/AwsProvisionerConfig.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/AwsProvisionerConfig.java
@@ -11,7 +11,7 @@ public class AwsProvisionerConfig
         extends ProvisionerConfig<AwsProvisionerConfig>
 {
 
-    private String awsCredentialsFile = "etc/aws-credentials.properties";
+    private String awsCredentialsFile = "persist/aws-credentials.properties";
 
     private String awsCoordinatorAmi = "ami-27b7744e";
     private String awsCoordinatorKeypair = "keypair";

--- a/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestAwsProvisionerConfig.java
+++ b/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestAwsProvisionerConfig.java
@@ -31,7 +31,7 @@ public class TestAwsProvisionerConfig
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(AwsProvisionerConfig.class)
                 .setAirshipVersion(null)
                 .setAgentDefaultConfig(null)
-                .setAwsCredentialsFile("etc/aws-credentials.properties")
+                .setAwsCredentialsFile("persist/aws-credentials.properties")
                 .setAwsCoordinatorAmi("ami-27b7744e")
                 .setAwsCoordinatorKeypair("keypair")
                 .setAwsCoordinatorSecurityGroup("default")


### PR DESCRIPTION
so that it is no longer clobbered in a coordinator upgrade.

Fixes #36
