### PR TITLE
Allowed for custom provisioning scripts.

### DIFF
--- a/airship-cli/src/main/java/io/airlift/airship/cli/Airship.java
+++ b/airship-cli/src/main/java/io/airlift/airship/cli/Airship.java
@@ -757,6 +757,9 @@ public class Airship
         @Option(name = "--instance-type", description = "Instance type to provision")
         public String instanceType;
 
+        @Option(name = "--provisioning-scripts-artifact", description = "The Maven artifact to use for the provisioning bootstrap")
+        public String provisioningScriptsArtifact;
+
         @Option(name = "--no-wait", description = "Do not wait for coordinator to start")
         public boolean noWait;
 
@@ -771,6 +774,7 @@ public class Airship
                     ami,
                     keyPair,
                     securityGroup,
+                    provisioningScriptsArtifact,
                     !noWait);
 
             // add the new coordinators to the config
@@ -796,6 +800,7 @@ public class Airship
             sb.append(", ami='").append(ami).append('\'');
             sb.append(", keyPair='").append(keyPair).append('\'');
             sb.append(", securityGroup='").append(securityGroup).append('\'');
+            sb.append(", provisioningScriptsArtifact='").append(provisioningScriptsArtifact).append('\'');
             sb.append(", availabilityZone='").append(availabilityZone).append('\'');
             sb.append(", instanceType='").append(instanceType).append('\'');
             sb.append('}');
@@ -880,6 +885,9 @@ public class Airship
         @Option(name = "--instance-type", description = "Instance type to provision")
         public String instanceType;
 
+        @Option(name = "--provisioning-scripts-artifact", description = "The Maven artifact to use for the provisioning bootstrap")
+        public String provisioningScriptsArtifact;
+
         @Option(name = "--no-wait", description = "Do not wait for agent to start")
         public boolean noWait;
 
@@ -887,7 +895,7 @@ public class Airship
         public void execute(Commander commander)
                 throws Exception
         {
-            List<AgentStatusRepresentation> agents = commander.provisionAgents(agentConfig, count, instanceType, availabilityZone, ami, keyPair, securityGroup, !noWait);
+            List<AgentStatusRepresentation> agents = commander.provisionAgents(agentConfig, count, instanceType, availabilityZone, ami, keyPair, securityGroup, provisioningScriptsArtifact, !noWait);
             displayAgents(agents);
         }
 
@@ -901,6 +909,7 @@ public class Airship
             sb.append(", ami='").append(ami).append('\'');
             sb.append(", keyPair='").append(keyPair).append('\'');
             sb.append(", securityGroup='").append(securityGroup).append('\'');
+            sb.append(", provisioningScriptsArtifact='").append(provisioningScriptsArtifact).append('\'');
             sb.append(", availabilityZone='").append(availabilityZone).append('\'');
             sb.append(", instanceType='").append(instanceType).append('\'');
             sb.append(", noWait=").append(noWait);
@@ -1085,6 +1094,9 @@ public class Airship
         @Option(name = "--coordinator-config", description = "Configuration for the coordinator")
         public String coordinatorConfig;
 
+        @Option(name = "--provisioning-scripts-artifact", description = "The Maven artifact to use for the provisioning bootstrap")
+        public String provisioningScriptsArtifact;
+
         @Option(name = "--repository", description = "Repository for binaries and configurations")
         public final List<String> repository = newArrayList();
 
@@ -1163,6 +1175,7 @@ public class Airship
                     ami,
                     keyPair,
                     securityGroup,
+                    provisioningScriptsArtifact,
                     httpServerConfig.getHttpPort(),
                     awsProvisionerConfig.getAwsCredentialsFile(),
                     this.repository);
@@ -1327,6 +1340,26 @@ public class Airship
                 }
             }
             return true;
+        }
+
+        @Override
+        public String toString()
+        {
+            final StringBuilder sb = new StringBuilder("EnvironmentProvisionAws{");
+            sb.append("environment='").append(environment).append('\'');
+            sb.append(", awsEndpoint='").append(awsEndpoint).append('\'');
+            sb.append(", ami='").append(ami).append('\'');
+            sb.append(", keyPair='").append(keyPair).append('\'');
+            sb.append(", securityGroup='").append(securityGroup).append('\'');
+            sb.append(", availabilityZone='").append(availabilityZone).append('\'');
+            sb.append(", instanceType='").append(instanceType).append('\'');
+            sb.append(", coordinatorConfig='").append(coordinatorConfig).append('\'');
+            sb.append(", provisioningScriptsArtifact='").append(provisioningScriptsArtifact).append('\'');
+            sb.append(", repository=").append(repository);
+            sb.append(", mavenDefaultGroupId=").append(mavenDefaultGroupId);
+            sb.append(", ref='").append(ref).append('\'');
+            sb.append('}');
+            return sb.toString();
         }
     }
 

--- a/airship-cli/src/main/java/io/airlift/airship/cli/Commander.java
+++ b/airship-cli/src/main/java/io/airlift/airship/cli/Commander.java
@@ -34,6 +34,7 @@ public interface Commander
             String ami,
             String keyPair,
             String securityGroup,
+            String provisioningScriptsArtifact,
             boolean waitForStartup);
 
     boolean sshCoordinator(CoordinatorFilter coordinatorFilter, String command);
@@ -47,6 +48,7 @@ public interface Commander
             String ami,
             String keyPair,
             String securityGroup,
+            String provisioningScriptsArtifact,
             boolean waitForStartup);
 
     AgentStatusRepresentation terminateAgent(String agentId);

--- a/airship-cli/src/main/java/io/airlift/airship/cli/CommanderFactory.java
+++ b/airship-cli/src/main/java/io/airlift/airship/cli/CommanderFactory.java
@@ -256,7 +256,8 @@ public class CommanderFactory
                 String availabilityZone,
                 String ami,
                 String keyPair,
-                String securityGroup)
+                String securityGroup,
+                String provisioningScriptsArtifact)
         {
             throw new UnsupportedOperationException("Coordinators can not be provisioned in local mode");
         }
@@ -275,7 +276,8 @@ public class CommanderFactory
                 String availabilityZone,
                 String ami,
                 String keyPair,
-                String securityGroup)
+                String securityGroup,
+                String provisioningScriptsArtifact)
         {
             throw new UnsupportedOperationException("Agents can not be provisioned in local mode");
         }

--- a/airship-cli/src/main/java/io/airlift/airship/cli/HttpCommander.java
+++ b/airship-cli/src/main/java/io/airlift/airship/cli/HttpCommander.java
@@ -198,6 +198,7 @@ public class HttpCommander implements Commander
             String ami,
             String keyPair,
             String securityGroup,
+            String provisioningScriptsArtifact,
             boolean waitForStartup)
     {
         URI uri = uriBuilderFrom(coordinatorUri).replacePath("v1/admin/coordinator").build();
@@ -209,7 +210,8 @@ public class HttpCommander implements Commander
                 availabilityZone,
                 ami,
                 keyPair,
-                securityGroup);
+                securityGroup,
+                provisioningScriptsArtifact);
 
         Request request = Request.Builder.preparePost()
                 .setUri(uri)
@@ -296,6 +298,7 @@ public class HttpCommander implements Commander
             String ami,
             String keyPair,
             String securityGroup,
+            String provisioningScriptsArtifact,
             boolean waitForStartup)
     {
         URI uri = uriBuilderFrom(coordinatorUri).replacePath("v1/admin/agent").build();
@@ -307,7 +310,8 @@ public class HttpCommander implements Commander
                 availabilityZone,
                 ami,
                 keyPair,
-                securityGroup);
+                securityGroup,
+                provisioningScriptsArtifact);
 
         Request request = Request.Builder.preparePost()
                 .setUri(uri)

--- a/airship-cli/src/main/java/io/airlift/airship/cli/LocalCommander.java
+++ b/airship-cli/src/main/java/io/airlift/airship/cli/LocalCommander.java
@@ -210,6 +210,7 @@ public class LocalCommander implements Commander
             String ami,
             String keyPair,
             String securityGroup,
+            String provisioningScriptsArtifact,
             boolean waitForStartup)
     {
         throw new UnsupportedOperationException("Coordinators can not be provisioned in local mode");
@@ -244,6 +245,7 @@ public class LocalCommander implements Commander
             String ami,
             String keyPair,
             String securityGroup,
+            String provisioningScriptsArtifact,
             boolean waitForStartup)
     {
         throw new UnsupportedOperationException("Agents can not be provisioned in local mode");

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/AdminResource.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/AdminResource.java
@@ -64,7 +64,8 @@ public class AdminResource
                 provisioning.getAvailabilityZone(),
                 provisioning.getAmi(),
                 provisioning.getKeyPair(),
-                provisioning.getSecurityGroup());
+                provisioning.getSecurityGroup(),
+                provisioning.getProvisioningScriptsArtifact());
 
         return Response.ok(transform(coordinators, fromCoordinatorStatus(coordinator.getCoordinators()))).build();
     }
@@ -103,7 +104,8 @@ public class AdminResource
                 provisioning.getAvailabilityZone(),
                 provisioning.getAmi(),
                 provisioning.getKeyPair(),
-                provisioning.getSecurityGroup());
+                provisioning.getSecurityGroup(),
+                provisioning.getProvisioningScriptsArtifact());
 
         return Response.ok(transform(agents, fromAgentStatus(coordinator.getAgents(), repository))).build();
     }

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/AgentProvisioningRepresentation.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/AgentProvisioningRepresentation.java
@@ -25,6 +25,7 @@ public class AgentProvisioningRepresentation
     private final String ami;
     private final String keyPair;
     private final String securityGroup;
+    private String provisioningScriptsArtifact;
 
     @JsonCreator
     public AgentProvisioningRepresentation(
@@ -34,7 +35,8 @@ public class AgentProvisioningRepresentation
             @JsonProperty("availabilityZone") String availabilityZone,
             @JsonProperty("ami") String ami,
             @JsonProperty("keyPair") String keyPair,
-            @JsonProperty("securityGroup") String securityGroup)
+            @JsonProperty("securityGroup") String securityGroup,
+            @JsonProperty("provisioningScriptsArtifact") String provisioningScriptsArtifact)
     {
         this.agentConfig = agentConfig;
         this.agentCount = agentCount;
@@ -43,6 +45,7 @@ public class AgentProvisioningRepresentation
         this.ami = ami;
         this.keyPair = keyPair;
         this.securityGroup = securityGroup;
+        this.provisioningScriptsArtifact = provisioningScriptsArtifact;
     }
 
     @JsonProperty
@@ -87,6 +90,12 @@ public class AgentProvisioningRepresentation
         return securityGroup;
     }
 
+    @JsonProperty
+    public String getProvisioningScriptsArtifact()
+    {
+        return provisioningScriptsArtifact;
+    }
+
     @Override
     public String toString()
     {
@@ -99,6 +108,7 @@ public class AgentProvisioningRepresentation
         sb.append(", ami='").append(ami).append('\'');
         sb.append(", keyPair='").append(keyPair).append('\'');
         sb.append(", securityGroup='").append(securityGroup).append('\'');
+        sb.append(", provisioningScriptsArtifact='").append(securityGroup).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/AwsProvisionerConfig.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/AwsProvisionerConfig.java
@@ -5,6 +5,8 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.Duration;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
 import java.util.concurrent.TimeUnit;
 
 public class AwsProvisionerConfig
@@ -22,6 +24,8 @@ public class AwsProvisionerConfig
     private String awsAgentKeypair = "keypair";
     private String awsAgentSecurityGroup = "default";
     private String awsAgentDefaultInstanceType = "t1.micro";
+
+    private String provisioningScriptsArtifact;
 
     // todo add zone
     private String awsEndpoint;
@@ -168,11 +172,6 @@ public class AwsProvisionerConfig
         return awsEndpoint;
     }
 
-    public String getS3KeystoreBucket()
-    {
-        return s3KeystoreBucket;
-    }
-
     @Config("coordinator.aws.s3-keystore.bucket")
     @ConfigDescription("S3 bucket for keystore")
     public AwsProvisionerConfig setS3KeystoreBucket(String s3KeystoreBucket)
@@ -181,9 +180,9 @@ public class AwsProvisionerConfig
         return this;
     }
 
-    public String getS3KeystorePath()
+    public String getS3KeystoreBucket()
     {
-        return s3KeystorePath;
+        return s3KeystoreBucket;
     }
 
     @Config("coordinator.aws.s3-keystore.path")
@@ -194,9 +193,9 @@ public class AwsProvisionerConfig
         return this;
     }
 
-    public Duration getS3KeystoreRefreshInterval()
+    public String getS3KeystorePath()
     {
-        return s3KeystoreRefreshInterval;
+        return s3KeystorePath;
     }
 
     @Config("coordinator.aws.s3-keystore.refresh")
@@ -205,5 +204,24 @@ public class AwsProvisionerConfig
     {
         this.s3KeystoreRefreshInterval = s3KeystoreRefreshInterval;
         return this;
+    }
+
+    public Duration getS3KeystoreRefreshInterval()
+    {
+        return s3KeystoreRefreshInterval;
+    }
+
+    @Config("coordinator.aws.provisioning.artifact")
+    @ConfigDescription("An alternate package of provisioning scripts")
+    public AwsProvisionerConfig setProvisioningScriptsArtifact(String provisioningScriptsArtifact)
+    {
+        this.provisioningScriptsArtifact = provisioningScriptsArtifact;
+        return this;
+    }
+
+    @Pattern(regexp = "[A-Za-z0-9_\\-.]+:[A-Za-z0-9_\\-.]+:[A-Za-z0-9_\\-.]+", message = "Invalid provisioning script artifact")
+    public String getProvisioningScriptsArtifact()
+    {
+        return provisioningScriptsArtifact;
     }
 }

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/Coordinator.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/Coordinator.java
@@ -238,7 +238,8 @@ public class Coordinator
             String availabilityZone,
             String ami,
             String keyPair,
-            String securityGroup)
+            String securityGroup,
+            String provisioningScriptsArtifact)
     {
         List<Instance> instances = provisioner.provisionCoordinators(coordinatorConfigSpec,
                 coordinatorCount,
@@ -246,7 +247,8 @@ public class Coordinator
                 availabilityZone,
                 ami,
                 keyPair,
-                securityGroup);
+                securityGroup,
+                provisioningScriptsArtifact);
 
         List<CoordinatorStatus> coordinators = newArrayList();
         for (Instance instance : instances) {
@@ -387,7 +389,8 @@ public class Coordinator
             String availabilityZone,
             String ami,
             String keyPair,
-            String securityGroup)
+            String securityGroup,
+            String provisioningScriptsArtifact)
     {
         List<Instance> instances = provisioner.provisionAgents(agentConfigSpec,
                 agentCount,
@@ -395,7 +398,8 @@ public class Coordinator
                 availabilityZone,
                 ami,
                 keyPair,
-                securityGroup);
+                securityGroup,
+                provisioningScriptsArtifact);
 
         List<AgentStatus> agents = newArrayList();
         for (Instance instance : instances) {

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorProvisioningRepresentation.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorProvisioningRepresentation.java
@@ -25,6 +25,7 @@ public class CoordinatorProvisioningRepresentation
     private final String ami;
     private final String keyPair;
     private final String securityGroup;
+    private String provisioningScriptsArtifact;
 
     @JsonCreator
     public CoordinatorProvisioningRepresentation(
@@ -34,7 +35,8 @@ public class CoordinatorProvisioningRepresentation
             @JsonProperty("availabilityZone") String availabilityZone,
             @JsonProperty("ami") String ami,
             @JsonProperty("keyPair") String keyPair,
-            @JsonProperty("securityGroup") String securityGroup)
+            @JsonProperty("securityGroup") String securityGroup,
+            @JsonProperty("provisioningScriptsArtifact") String provisioningScriptsArtifact)
     {
         this.coordinatorConfig = coordinatorConfig;
         this.coordinatorCount = coordinatorCount;
@@ -43,6 +45,7 @@ public class CoordinatorProvisioningRepresentation
         this.ami = ami;
         this.keyPair = keyPair;
         this.securityGroup = securityGroup;
+        this.provisioningScriptsArtifact = provisioningScriptsArtifact;
     }
 
     @JsonProperty
@@ -87,6 +90,12 @@ public class CoordinatorProvisioningRepresentation
         return securityGroup;
     }
 
+    @JsonProperty
+    public String getProvisioningScriptsArtifact()
+    {
+        return provisioningScriptsArtifact;
+    }
+
     @Override
     public String toString()
     {
@@ -99,6 +108,7 @@ public class CoordinatorProvisioningRepresentation
         sb.append(", ami='").append(ami).append('\'');
         sb.append(", keyPair='").append(keyPair).append('\'');
         sb.append(", securityGroup='").append(securityGroup).append('\'');
+        sb.append(", provisioningScriptsArtifact='").append(provisioningScriptsArtifact).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/Provisioner.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/Provisioner.java
@@ -12,7 +12,8 @@ public interface Provisioner
             String availabilityZone,
             String ami,
             String keyPair,
-            String securityGroup);
+            String securityGroup,
+            String provisioningScriptsArtifact);
 
     List<Instance> listAgents();
 
@@ -22,7 +23,8 @@ public interface Provisioner
             String availabilityZone,
             String ami,
             String keyPair,
-            String securityGroup);
+            String securityGroup,
+            String provisioningScriptsArtifact);
 
     void terminateAgents(Iterable<String> instanceIds);
 }

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/StaticProvisioner.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/StaticProvisioner.java
@@ -147,7 +147,8 @@ public class StaticProvisioner
             String availabilityZone,
             String ami,
             String keyPair,
-            String securityGroup)
+            String securityGroup,
+            String provisioningScriptsArtifact)
     {
         throw new UnsupportedOperationException("Static provisioner does not support coordinator provisioning");
     }
@@ -211,7 +212,8 @@ public class StaticProvisioner
             String availabilityZone,
             String ami,
             String keyPair,
-            String securityGroup)
+            String securityGroup,
+            String provisioningScriptsArtifact)
     {
         throw new UnsupportedOperationException("Static provisioner does not support agent provisioning");
     }

--- a/airship-coordinator/src/test/java/io/airlift/airship/coordinator/MockProvisioner.java
+++ b/airship-coordinator/src/test/java/io/airlift/airship/coordinator/MockProvisioner.java
@@ -89,7 +89,8 @@ public class MockProvisioner implements Provisioner
             String availabilityZone,
             String ami,
             String keyPair,
-            String securityGroup)
+            String securityGroup,
+            String provisioningScriptsArtifact)
     {
         ImmutableList.Builder<Instance> instances = ImmutableList.builder();
         for (int i = 0; i < coordinatorCount; i++) {
@@ -209,7 +210,8 @@ public class MockProvisioner implements Provisioner
             String availabilityZone,
             String ami,
             String keyPair,
-            String securityGroup)
+            String securityGroup,
+            String provisioningScriptsArtifact)
     {
         if (instanceType == null) {
             instanceType = "default";

--- a/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestAdminResource.java
+++ b/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestAdminResource.java
@@ -153,7 +153,7 @@ public class TestAdminResource
         String instanceType = "instance-type";
         URI requestUri = URI.create("http://localhost/v1/admin/coordinator");
         Response response = resource.provisionCoordinator(
-                new CoordinatorProvisioningRepresentation("coordinator:config:1", 1, instanceType, null, null, null, null),
+                new CoordinatorProvisioningRepresentation("coordinator:config:1", 1, instanceType, null, null, null, null, null),
                 MockUriInfo.from(requestUri)
         );
         assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
@@ -264,7 +264,7 @@ public class TestAdminResource
         String instanceType = "instance-type";
         URI requestUri = URI.create("http://localhost/v1/admin/agent");
         Response response = resource.provisionAgent(
-                new AgentProvisioningRepresentation("agent:config:1", 1, instanceType, null, null, null, null),
+                new AgentProvisioningRepresentation("agent:config:1", 1, instanceType, null, null, null, null, null),
                 MockUriInfo.from(requestUri)
         );
         assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());

--- a/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestCoordinator.java
+++ b/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestCoordinator.java
@@ -155,7 +155,7 @@ public class TestCoordinator
     {
         // provision the coordinator and verify
         String instanceType = "instance-type";
-        List<CoordinatorStatus> coordinators = coordinator.provisionCoordinators("coordinator:config:1", 1, instanceType, null, null, null, null);
+        List<CoordinatorStatus> coordinators = coordinator.provisionCoordinators("coordinator:config:1", 1, instanceType, null, null, null, null, null);
         assertNotNull(coordinators);
         assertEquals(coordinators.size(), 1);
         String instanceId = coordinators.get(0).getInstanceId();
@@ -268,7 +268,7 @@ public class TestCoordinator
     {
         // provision the agent and verify
         String instanceType = "instance-type";
-        List<AgentStatus> agents = coordinator.provisionAgents("agent:config:1", 1, instanceType, null, null, null, null);
+        List<AgentStatus> agents = coordinator.provisionAgents("agent:config:1", 1, instanceType, null, null, null, null, null);
         assertNotNull(agents);
         assertEquals(agents.size(), 1);
         String instanceId = agents.get(0).getInstanceId();

--- a/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestCoordinatorServer.java
+++ b/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestCoordinatorServer.java
@@ -302,7 +302,7 @@ public class TestCoordinatorServer
     {
         // provision the coordinator and verify
         String instanceType = "instance-type";
-        CoordinatorProvisioningRepresentation coordinatorProvisioningRepresentation = new CoordinatorProvisioningRepresentation("coordinator:config:1", 1, instanceType, null, null, null, null);
+        CoordinatorProvisioningRepresentation coordinatorProvisioningRepresentation = new CoordinatorProvisioningRepresentation("coordinator:config:1", 1, instanceType, null, null, null, null, null);
         Request request = Request.Builder.preparePost()
                 .setUri(coordinatorUriBuilder().appendPath("/v1/admin/coordinator").build())
                 .setHeader(CONTENT_TYPE, APPLICATION_JSON)
@@ -425,7 +425,7 @@ public class TestCoordinatorServer
     {
         // provision the agent and verify
         String instanceType = "instance-type";
-        AgentProvisioningRepresentation agentProvisioningRepresentation = new AgentProvisioningRepresentation("agent:config:1", 1, instanceType, null, null, null, null);
+        AgentProvisioningRepresentation agentProvisioningRepresentation = new AgentProvisioningRepresentation("agent:config:1", 1, instanceType, null, null, null, null, null);
         Request request = Request.Builder.preparePost()
                 .setUri(coordinatorUriBuilder().appendPath("/v1/admin/agent").build())
                 .setHeader(CONTENT_TYPE, APPLICATION_JSON)

--- a/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestProvisionAgent.java
+++ b/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestProvisionAgent.java
@@ -58,7 +58,7 @@ public class TestProvisionAgent
                 awsProvisionerConfig);
 
         int agentCount = 2;
-        List<Instance> provisioned = provisioner.provisionAgents(null, agentCount, null, null, null, null, null);
+        List<Instance> provisioned = provisioner.provisionAgents(null, agentCount, null, null, null, null, null, null);
         assertEquals(provisioned.size(), agentCount);
         System.err.println("provisioned instances: " + provisioned);
 

--- a/airship-integration-tests/src/test/java/io/airlift/airship/integration/MockLocalProvisioner.java
+++ b/airship-integration-tests/src/test/java/io/airlift/airship/integration/MockLocalProvisioner.java
@@ -61,7 +61,8 @@ public class MockLocalProvisioner implements Provisioner
             String availabilityZone,
             String ami,
             String keyPair,
-            String securityGroup)
+            String securityGroup,
+            String provisioningScriptsArtifact)
     {
         List<Instance> instances = newArrayList();
         for (int i = 0; i < coordinatorCount; i++) {
@@ -257,7 +258,8 @@ public class MockLocalProvisioner implements Provisioner
             String availabilityZone,
             String ami,
             String keyPair,
-            String securityGroup)
+            String securityGroup,
+            String provisioningScriptsArtifact)
     {
         if (instanceType == null) {
             instanceType = "default";

--- a/airship-integration-tests/src/test/java/io/airlift/airship/integration/TestServerIntegration.java
+++ b/airship-integration-tests/src/test/java/io/airlift/airship/integration/TestServerIntegration.java
@@ -229,7 +229,7 @@ public class TestServerIntegration
     private void initializeOneAgent()
             throws Exception
     {
-        List<Instance> instances = provisioner.provisionAgents("agent:config:1", 1, "instance-type", null, null, null, null);
+        List<Instance> instances = provisioner.provisionAgents("agent:config:1", 1, "instance-type", null, null, null, null, null);
         assertEquals(instances.size(), 1);
         AgentServer agentServer = provisioner.getAgent(instances.get(0).getInstanceId());
         assertNotNull(agentServer);
@@ -268,7 +268,7 @@ public class TestServerIntegration
             throws Exception
     {
         // directly add a new coordinator and start it
-        List<Instance> instances = provisioner.provisionCoordinators("coordinator:config:1", 1, "instance-type", null, null, null, null);
+        List<Instance> instances = provisioner.provisionCoordinators("coordinator:config:1", 1, "instance-type", null, null, null, null, null);
         assertEquals(instances.size(), 1);
         CoordinatorServer coordinatorServer = provisioner.getCoordinator(instances.get(0).getInstanceId());
         coordinatorServer.start();
@@ -297,7 +297,7 @@ public class TestServerIntegration
     {
         // provision the coordinator and verify
         String instanceType = "instance-type";
-        CoordinatorProvisioningRepresentation coordinatorProvisioningRepresentation = new CoordinatorProvisioningRepresentation("coordinator:config:1", 1, instanceType, null, null, null, null);
+        CoordinatorProvisioningRepresentation coordinatorProvisioningRepresentation = new CoordinatorProvisioningRepresentation("coordinator:config:1", 1, instanceType, null, null, null, null, null);
         Request request = Request.Builder.preparePost()
                 .setUri(coordinatorUriBuilder().appendPath("/v1/admin/coordinator").build())
                 .setHeader(CONTENT_TYPE, APPLICATION_JSON)
@@ -376,7 +376,7 @@ public class TestServerIntegration
             throws Exception
     {
         // directly add a new agent and start it
-        List<Instance> instances = provisioner.provisionAgents("agent:config:1", 1, "instance-type", null, null, null, null);
+        List<Instance> instances = provisioner.provisionAgents("agent:config:1", 1, "instance-type", null, null, null, null, null);
         assertEquals(instances.size(), 1);
         AgentServer agentServer = provisioner.getAgent(instances.get(0).getInstanceId());
         agentServer.start();
@@ -409,7 +409,7 @@ public class TestServerIntegration
     {
         // provision the agent and verify
         String instanceType = "instance-type";
-        AgentProvisioningRepresentation agentProvisioningRepresentation = new AgentProvisioningRepresentation("agent:config:1", 1, instanceType, null, null, null, null);
+        AgentProvisioningRepresentation agentProvisioningRepresentation = new AgentProvisioningRepresentation("agent:config:1", 1, instanceType, null, null, null, null, null);
         Request request = Request.Builder.preparePost()
                 .setUri(coordinatorUriBuilder().appendPath("/v1/admin/agent").build())
                 .setHeader(CONTENT_TYPE, APPLICATION_JSON)


### PR DESCRIPTION
This patch lets you specify a custom artifact containing the provisioning scripts to use for aws instances. The artifact format needs to have the exact same files as the airship-ec2 module in this project.
