### PR TITLE
Fix bugs with allow-duplicate-installations-on-an-agent.

### DIFF
--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/AdminResource.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/AdminResource.java
@@ -32,14 +32,14 @@ public class AdminResource
 {
     private final Coordinator coordinator;
     private final Repository repository;
-    private final CoordinatorConfig config;
+    private final boolean allowDuplicateInstallationsOnAnAgent;
 
     @Inject
     public AdminResource(Coordinator coordinator, Repository repository, CoordinatorConfig config)
     {
         this.coordinator = coordinator;
         this.repository = repository;
-        this.config = config;
+        this.allowDuplicateInstallationsOnAnAgent = config.isAllowDuplicateInstallationsOnAnAgent();
     }
 
     @GET
@@ -82,7 +82,7 @@ public class AdminResource
         Predicate<AgentStatus> agentPredicate = AgentFilterBuilder.build(uriInfo,
                 transform(coordinator.getAgents(), idGetter()),
                 transform(allSlotStatus, SlotStatus.uuidGetter()),
-                config.isAllowDuplicateInstallationsOnAnAgent(),
+                allowDuplicateInstallationsOnAnAgent,
                 repository);
 
         List<AgentStatus> agents = coordinator.getAgents(agentPredicate);

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/AdminResource.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/AdminResource.java
@@ -32,12 +32,14 @@ public class AdminResource
 {
     private final Coordinator coordinator;
     private final Repository repository;
+    private final CoordinatorConfig config;
 
     @Inject
-    public AdminResource(Coordinator coordinator, Repository repository)
+    public AdminResource(Coordinator coordinator, Repository repository, CoordinatorConfig config)
     {
         this.coordinator = coordinator;
         this.repository = repository;
+        this.config = config;
     }
 
     @GET
@@ -80,7 +82,7 @@ public class AdminResource
         Predicate<AgentStatus> agentPredicate = AgentFilterBuilder.build(uriInfo,
                 transform(coordinator.getAgents(), idGetter()),
                 transform(allSlotStatus, SlotStatus.uuidGetter()),
-                false,
+                config.isAllowDuplicateInstallationsOnAnAgent(),
                 repository);
 
         List<AgentStatus> agents = coordinator.getAgents(agentPredicate);

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorSlotResource.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorSlotResource.java
@@ -56,18 +56,18 @@ public class CoordinatorSlotResource
 
     private final Coordinator coordinator;
     private final Repository repository;
-    private final CoordinatorConfig config;
+    private final boolean allowDuplicateInstallationsOnAnAgent;
 
     @Inject
     public CoordinatorSlotResource(Coordinator coordinator, Repository repository, CoordinatorConfig config)
     {
         Preconditions.checkNotNull(coordinator, "coordinator must not be null");
         Preconditions.checkNotNull(repository, "repository is null");
+        Preconditions.checkNotNull(config, "coordinatorConfig is null");
 
         this.coordinator = coordinator;
         this.repository = repository;
-
-        this.config = Preconditions.checkNotNull(config, "coordinatorConfig is null");
+        this.allowDuplicateInstallationsOnAnAgent = config.isAllowDuplicateInstallationsOnAnAgent();
     }
 
     @GET
@@ -105,7 +105,7 @@ public class CoordinatorSlotResource
         Predicate<AgentStatus> agentFilter = AgentFilterBuilder.build(uriInfo,
                 transform(coordinator.getAgents(), idGetter()),
                 transform(coordinator.getAllSlotStatus(), uuidGetter()),
-                config.isAllowDuplicateInstallationsOnAnAgent(),
+                allowDuplicateInstallationsOnAnAgent,
                 repository);
         List<AgentStatus> agents = coordinator.getAgents(agentFilter);
 

--- a/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorSlotResource.java
+++ b/airship-coordinator/src/main/java/io/airlift/airship/coordinator/CoordinatorSlotResource.java
@@ -56,15 +56,18 @@ public class CoordinatorSlotResource
 
     private final Coordinator coordinator;
     private final Repository repository;
+    private final CoordinatorConfig config;
 
     @Inject
-    public CoordinatorSlotResource(Coordinator coordinator, Repository repository)
+    public CoordinatorSlotResource(Coordinator coordinator, Repository repository, CoordinatorConfig config)
     {
         Preconditions.checkNotNull(coordinator, "coordinator must not be null");
         Preconditions.checkNotNull(repository, "repository is null");
 
         this.coordinator = coordinator;
         this.repository = repository;
+
+        this.config = Preconditions.checkNotNull(config, "coordinatorConfig is null");
     }
 
     @GET
@@ -102,7 +105,7 @@ public class CoordinatorSlotResource
         Predicate<AgentStatus> agentFilter = AgentFilterBuilder.build(uriInfo,
                 transform(coordinator.getAgents(), idGetter()),
                 transform(coordinator.getAllSlotStatus(), uuidGetter()),
-                false,
+                config.isAllowDuplicateInstallationsOnAnAgent(),
                 repository);
         List<AgentStatus> agents = coordinator.getAgents(agentFilter);
 

--- a/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestAdminResource.java
+++ b/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestAdminResource.java
@@ -61,7 +61,7 @@ public class TestAdminResource
                 new MockServiceInventory(),
                 new Duration(1, TimeUnit.DAYS),
                 false);
-        resource = new AdminResource(coordinator, repository);
+        resource = new AdminResource(coordinator, repository, new CoordinatorConfig());
     }
 
     @AfterMethod

--- a/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestCoordinatorSlotResource.java
+++ b/airship-coordinator/src/test/java/io/airlift/airship/coordinator/TestCoordinatorSlotResource.java
@@ -50,20 +50,21 @@ public class TestCoordinatorSlotResource
             throws Exception
     {
         NodeInfo nodeInfo = new NodeInfo("testing");
+        CoordinatorConfig config = new CoordinatorConfig().setStatusExpiration(new Duration(1, TimeUnit.DAYS));
 
         repository = new TestingMavenRepository();
 
         provisioner = new MockProvisioner();
         coordinator = new Coordinator(nodeInfo,
                 new HttpServerInfo(new HttpServerConfig(), nodeInfo),
-                new CoordinatorConfig().setStatusExpiration(new Duration(1, TimeUnit.DAYS)),
+                config,
                 provisioner.getCoordinatorFactory(),
                 provisioner.getAgentFactory(),
                 repository,
                 provisioner,
                 new InMemoryStateManager(),
                 new MockServiceInventory());
-        resource = new CoordinatorSlotResource(coordinator, repository);
+        resource = new CoordinatorSlotResource(coordinator, repository, config);
     }
 
     @AfterMethod


### PR DESCRIPTION
- Make sure that the config setting is respected everywhere.
- If less agents than requested installs are present and duplicate installation is allowed, install
  more than one instance of a service per agent.
